### PR TITLE
Get back to work right meow

### DIFF
--- a/capi/templates/default/bash_it/custom/capi-aliases.bash
+++ b/capi/templates/default/bash_it/custom/capi-aliases.bash
@@ -1,13 +1,29 @@
 alias resprout='(cd ~/workspace/sprout-capi && git pull && chruby-exec system -- bundle exec soloist)'
+
+# CATs
 alias cats='(cd ~/workspace/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests && CONFIG=$PWD/integration_config.json bin/test_default -p)'
 alias v3-cats='(cd ~/workspace/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests && CONFIG=$PWD/integration_config.json bin/test -p v3)'
+
+alias cats-notify='(cd ~/workspace/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests && CONFIG=$PWD/integration_config.json bin/test_default -p ; get_back_to_work cats)'
+alias v3-cats-notify='(cd ~/workspace/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests && CONFIG=$PWD/integration_config.json bin/test -p v3 ; get_back_to_work cats )'
+alias all-da-cats-notify='(cd ~/workspace/cf-release/src/github.com/cloudfoundry/cf-acceptance-tests && CONFIG=$PWD/integration_config.json bin/test_default -p && bin/test -p v3 ; get_back_to_work cats)'
 
 # Bosh-lite setup
 alias qnd-deploy='(cd ~/workspace/cf-release && scripts/deploy --no-manifest)'
 alias qnd-deploy-diego='(cd ~/workspace/diego-release && bosh --parallel 10 sync blobs && scripts/update && scripts/deploy && bosh deployment ~/workspace/cf-release/bosh-lite/deployments/cf.yml)'
 alias qnd-deploy-manifest='(cd ~/workspace/cf-release && scripts/deploy)'
 
+alias qnd-deploy-notify='(cd ~/workspace/cf-release && scripts/deploy --no-manifest ; get_back_to_work)'
+alias qnd-deploy-diego-notify='(cd ~/workspace/diego-release && bosh --parallel 10 sync blobs && scripts/update && scripts/deploy && bosh deployment ~/workspace/cf-release/bosh-lite/deployments/cf.yml ; get_back_to_work)'
+alias qnd-deploy-manifest-notify='(cd ~/workspace/cf-release && scripts/deploy ; get_back_to_work)'
+
+# PSQL
 alias psql-bosh-lite='psql -h 10.244.0.30 -p 5524 -U ccadmin ccdb'
+
+# Notify
+
+alias notify='(get_back_to_work)'
+alias notify-cats='(get_back_to_work cats)'
 
 #FASD
 alias v='fasd -e vim'

--- a/capi/templates/default/bash_it/custom/delete_orgs.bash
+++ b/capi/templates/default/bash_it/custom/delete_orgs.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function delete_orgs() {
+  echo "Warning! All of your orgs and everything in them will be deleted!"
+
+  i=1
+
+  cf orgs | while read line; do
+    echo $line
+    if [ $i -gt 3 ]; then
+      cf delete-org -f "$line";
+    fi
+    ((i++))
+  done
+
+}
+
+export -f delete_orgs

--- a/capi/templates/default/bash_it/custom/get_back_to_work.bash
+++ b/capi/templates/default/bash_it/custom/get_back_to_work.bash
@@ -1,0 +1,34 @@
+function get_back_to_work() {
+  last_exit_code=$(echo $?)
+
+  author1=$(git config duet.env.git-author-name)
+  author2=$(git config duet.env.git-committer-name)
+
+  author1array=($author1)
+
+  if [[ -z $author2 ]]; then
+    last_names="${author1array[1]}"
+  else
+    author2array=($author2)
+    last_names="${author1array[1]}%20and%20${author2array[1]}"
+  fi
+
+  if [ "$1" == 'cats' ]; then
+    success="http://get-back-to-work-meow.cfapps.io/cat-success/${last_names}"
+    fail="http://get-back-to-work-meow.cfapps.io/cat-fail/${last_names}"
+  else
+    success="http://get-back-to-work-meow.cfapps.io/default-success/${last_names}"
+    fail="http://get-back-to-work-meow.cfapps.io/default-fail/${last_names}"
+  fi
+
+  if [ $last_exit_code -eq 130 ]; then
+    exit 0
+  elif [ $last_exit_code -eq 0 ]; then
+    open $success
+  else
+    open $fail
+  fi
+}
+export -f get_back_to_work
+
+

--- a/soloistrc
+++ b/soloistrc
@@ -175,6 +175,8 @@ node_attributes:
         - bash_it/custom/recreate_bosh_lite.bash
         - bash_it/custom/setup-direnv.bash
         - bash_it/custom/fast_bosh.bash
+        - bash_it/custom/get_back_to_work.bash
+        - bash_it/custom/delete_orgs.bash
         - bash_it/custom/pullify.bash
   atom:
     packages:


### PR DESCRIPTION
This branch contains 
- `get_back_to_work` script that has been appended to many long running aliases.
  - it will pop up a chome page when your CAT or deployment is done
  - if you CLT + C it should not pop up a page
  - contains fun git duet integration for personalized messages 
- `delete_orgs` scripts that will delete all of your cf orgs. Great for cleanup after many failed CATs.
