### PR TITLE
soloistrc works on macOS Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 This project uses [soloist](https://github.com/mkocher/soloist) and [librarian-chef](https://github.com/applicationsonline/librarian-chef)
 to run a subset of the recipes in sprout's cookbooks.
 
-[Fork it](https://github.com/pivotal-sprout/sprout-wrap/fork) to 
-customize its [attributes](http://docs.chef.io/attributes.html) in [soloistrc](/soloistrc) and the list of recipes 
-you'd like to use for your team. You may also want to add other cookbooks to its [Cheffile](/Cheffile), perhaps one 
-of the many [community cookbooks](https://supermarket.chef.io/cookbooks). By default it configures an OS X 
+[Fork it](https://github.com/pivotal-sprout/sprout-wrap/fork) to
+customize its [attributes](http://docs.chef.io/attributes.html) in [soloistrc](/soloistrc) and the list of recipes
+you'd like to use for your team. You may also want to add other cookbooks to its [Cheffile](/Cheffile), perhaps one
+of the many [community cookbooks](https://supermarket.chef.io/cookbooks). By default it configures an OS X
 Mavericks workstation for Ruby development.
 
-Finally, if you've never used Chef before - we highly recommend you buy &amp; watch [this excellent 17 minute screencast](http://railscasts.com/episodes/339-chef-solo-basics) by Ryan Bates. 
+Finally, if you've never used Chef before - we highly recommend you buy &amp; watch [this excellent 17 minute screencast](http://railscasts.com/episodes/339-chef-solo-basics) by Ryan Bates.
 
 ## Installation under Mavericks (OS X 10.9)
 
 ### 1. Install Command Line Tools
-  
+
     xcode-select --install
 
 If you receive a message about the update server being unavailable and are on Mavericks, then you already have the command line tools.
@@ -54,6 +54,22 @@ one may want to run the following commands:
 
 ```
 recreate_bosh_lite
+```
+## Installation under Sierra (macOS 10.12)
+
+The instructions are similar to those of OS X Mavericks.
+
+You may see an error similar to the following:
+
+```
+Permission denied - /Users/jill-user/Library/Caches/Homebrew/Cask/flycut--1.8.zip.incomplete`
+```
+
+It's caused by files in the home directory not owned by the user.
+The solution is to fix the ownerships:
+
+```
+sudo chown -R $USER ~
 ```
 
 ## Caveats

--- a/soloistrc
+++ b/soloistrc
@@ -218,7 +218,6 @@ node_attributes:
       - jq
       - node
       - pstree
-      - qt
       - s3cmd
       - ssh-copy-id
       - tig
@@ -237,7 +236,6 @@ node_attributes:
       - itsycal
       - karabiner
       - macvim
-      - menumeters
       - mou
       - sequel-pro
       - screenhero
@@ -247,7 +245,6 @@ node_attributes:
       - virtualbox
       - atom
       - xscope
-      - bittorrent-sync
     taps:
       - cloudfoundry/tap
       - universal-ctags/universal-ctags


### PR DESCRIPTION
- updated README with instructions for macOS Sierra
  - removed trailing whitespace of dubious origin
- removed `qt`; fixes:

```
This formula either does not compile or function as expected on macOS
versions newer than El Capitan due to an upstream incompatibility
```
- removed `menumeters`; fixes:

```
menumeters # Error: Cask menumeters depends on macOS release <= 10.10, but you are running release 10.12.
```
- removed `bittorrent-sync`; fixes:

```
Error: No available Cask for bittorrent-sync
```

_sprout-capi_ has become the canonical sprout-wrap, so I'm submitting my pull-request here. Thanks @wendorf & everyone else who contributed to this great resource — I was able to sprout my laptop with macOS sierra within a single day (and the biggest problem? Installing Quicken, which wasn't part of sprout-wrap).
